### PR TITLE
Bump to 1.5.0-alpha.10

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-issues: {uri-repo}/issues
 :uri-ci: {uri-repo}/actions?query=workflow%3ACI
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 1.5.0-alpha.8
+:artifact-version: 1.5.0-alpha.10
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}

--- a/asciidoctorj-epub3/gradle.properties
+++ b/asciidoctorj-epub3/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ EPUB3
 description=AsciidoctorJ EPUB3 bundles the Asciidoctor EPUB3 RubyGem (asciidoctor-epub3) so it can be loaded into the JVM using JRuby.
-version=1.5.0-alpha.8
+version=1.5.0-alpha.10
 gem_name=asciidoctor-epub3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.5.0-alpha.8
+version=1.5.0-alpha.10


### PR DESCRIPTION
Release notes: https://github.com/asciidoctor/asciidoctor-epub3/releases/tag/v1.5.0.alpha.10