### PR TITLE
Add GitHub Actions script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: check

--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-asciidoctorj: https://github.com/asciidoctor/asciidoctorj
 :uri-repo: https://github.com/asciidoctor/asciidoctorj-diagram
 :uri-issues: {uri-repo}/issues
+:uri-ci: {uri-repo}/actions?query=workflow%3ACI
 :uri-discuss: http://discuss.asciidoctor.org
 :artifact-version: 1.5.0-alpha.8
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
@@ -37,12 +38,10 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 
 {uri-repo}[AsciidoctorJ EPUB3] is a convenient repackaging of Asciidoctor EPUB3 for use with {uri-asciidoctorj}[AsciidoctorJ], which brings the Asciidoctor ecosystem to the JVM.
 
-// TODO: Fix URLs for badges once CI is configured
 ifdef::badges[]
-image:https://img.shields.io/travis/asciidoctor/asciidoctorj/master.svg[Build Status (Travis CI), link=https://travis-ci.org/asciidoctor/asciidoctorj-epub3]
+image:{uri-repo}/workflows/CI/badge.svg[GitHub Actions,link={uri-ci}]
 endif::[]
 
 ifdef::awestruct,env-browser[]
 toc::[]
 endif::[]
-


### PR DESCRIPTION
Currently, asciidoctorj-epub3 doesn't have any CI configured. Let it have some.

You may see example runs here: https://github.com/slonopotamus/asciidoctorj-epub3/actions