### PR TITLE
Bump asciidoctor-epub3 to 1.5.0-alpha.12

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ ifndef::awestruct[:uri-docs: http://asciidoctor.org/docs]
 :uri-issues: {uri-repo}/issues
 :uri-ci: {uri-repo}/actions?query=workflow%3ACI
 :uri-discuss: http://discuss.asciidoctor.org
-:artifact-version: 1.5.0-alpha.10
+:artifact-version: 1.5.0-alpha.12
 :uri-maven-artifact-query: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.asciidoctor%22%20AND%20a%3A%22asciidoctorj%22%20AND%20v%3A%22{artifact-version}%22
 :uri-maven-artifact-detail: http://search.maven.org/#artifactdetails%7Corg.asciidoctor%7Casciidoctorj%7C{artifact-version}%7Cjar
 :uri-maven-artifact-file: http://search.maven.org/remotecontent?filepath=org/asciidoctor/asciidoctorj/{artifact-version}/asciidoctorj-{artifact-version}

--- a/asciidoctorj-epub3/gradle.properties
+++ b/asciidoctorj-epub3/gradle.properties
@@ -1,4 +1,4 @@
 properName=AsciidoctorJ EPUB3
 description=AsciidoctorJ EPUB3 bundles the Asciidoctor EPUB3 RubyGem (asciidoctor-epub3) so it can be loaded into the JVM using JRuby.
-version=1.5.0-alpha.11
+version=1.5.0-alpha.12
 gem_name=asciidoctor-epub3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.5.0-alpha.11
+version=1.5.0-alpha.12


### PR DESCRIPTION
I was not planning to release alpha-12 so soon, but I had because of asciidoctor/asciidoctor-epub3#269 regression.
