### PR TITLE
Publish to Maven central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,17 @@ jobs:
   test:
     strategy:
       matrix:
-        java: ['1.8', '11']
+        java: ['1.8', '11', '15']
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: macos-latest
             java: '1.8'
+          - os: macos-latest
+            java: '15'
           - os: windows-latest
             java: '1.8'
+          - os: windows-latest
+            java: '15'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/asciidoctorj-epub3/build.gradle
+++ b/asciidoctorj-epub3/build.gradle
@@ -22,3 +22,8 @@ jrubyPrepare {
     }
   }
 }
+
+ext.publicationName = "mavenAsciidoctorJEpub3"
+
+apply from: rootProject.file('gradle/publish.gradle')
+apply from: rootProject.file('gradle/signing.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,34 @@
     we don't need to apply the jruby and bintray plugin on the rootProject.
 */
 buildscript {
-    repositories {
-        jcenter()
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
     }
-    dependencies {
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
-    }
+    mavenCentral()
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+  }
 }
 
 // modern plugins config
 plugins {
+  id "signing"
+  id "io.codearte.nexus-staging" version "0.22.0"
+  id "de.marcphilipp.nexus-publish" version "0.4.0"
   id 'com.github.jruby-gradle.base' version '2.0.0'
+}
+
+apply plugin: 'io.codearte.nexus-staging'
+
+
+nexusStaging {
+  if (project.hasProperty("sonatypeUsername")) {
+    username = project.sonatypeUsername
+  }
+  if (project.hasProperty("sonatypePassword")) {
+    password = project.sonatypePassword
+  }
+  repositoryDescription = "Release ${project.group} ${project.version}"
 }
 
 // TIP use -PpublishRelease=true to active release behavior regardless of the version
@@ -57,14 +73,6 @@ subprojects {
   apply plugin: 'java'
   apply from: "$rootDir/gradle/providedConfiguration.gradle"
 
-  apply from: rootProject.file('gradle/signing.gradle')
-  if (!it.name.endsWith('itest')) {
-    apply from: rootProject.file('gradle/publish.gradle')
-  }
-  if (statusIsRelease) {
-    apply from: rootProject.file('gradle/deploy.gradle')
-  }
-
   status = _status
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle
@@ -87,7 +95,7 @@ subprojects {
       mavenLocal()
     }
 
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -156,21 +164,9 @@ configure(subprojects.findAll {it.name != 'itest'}) {
 
 configure(subprojects.findAll { it.name != 'itest'}) {
 
-  task sourcesJar(type: Jar, dependsOn: classes, group: 'Release') {
-    description 'Assembles a jar archive containing the main source code.'
-    from sourceSets.main.allSource
-    classifier 'sources'
-  }
-
-  task javadocJar(type: Jar, dependsOn: javadoc, group: 'Release') {
-    description 'Assembles a jar archive containing the Javadoc API documentation for the main source code.'
-    from javadoc.destinationDir
-    classifier 'javadoc'
-  }
-
-  // jcenter & Maven Central requires sources & javadoc jars (even if empty), so give 'em what they want
-  artifacts {
-    archives sourcesJar, javadocJar
+  java {
+    withJavadocJar()
+    withSourcesJar()
   }
 
   jruby {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,125 +1,96 @@
-// NOTE replace deficient built-in publishing plugin with nebula-publishing,
-// which does a better job generating the POM and properly aggregates signature files for upload to Bintray
-apply plugin: 'maven-publish'
+apply plugin: 'de.marcphilipp.nexus-publish'
 
-def projectMeta = {
-    resolveStrategy = groovy.lang.Closure.DELEGATE_FIRST
-    name project.name
-    description project.description
-    url 'https://github.com/asciidoctor/asciidoctorj-epub3'
-    inceptionYear '2013'
-    licenses {
-        license {
-            name 'The Apache Software License, Version 2.0'
-            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-            distribution 'repo'
-        }
-    }
-    issueManagement {
-        system 'github'
-        url 'https://github.com/asciidoctor/asciidoctorj-epub3/issues'
-    }
-    scm {
-        url 'https://github.com/asciidoctor/asciidoctorj-epub3'
-    }
-    developers {
-        developer {
-            id 'asotobu'
-            name 'Alex Soto Bueno'
-            email 'asotobu@gmail.com'
-            timezone '1'
-            roles {
-                role 'Project Lead'
+publishing {
+    publications.create(project.ext.publicationName, MavenPublication) {
+
+        from components.java
+
+        pom {
+            name = project.name
+            description = project.description
+            url = 'https://github.com/asciidoctor/asciidoctorj-epub3'
+            inceptionYear = '2013'
+            licenses {
+                license {
+                    name = 'The Apache Software License, Version 2.0'
+                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution = 'repo'
+                }
             }
-        }
-        developer {
-            id 'mojavelinux'
-            name 'Dan Allen'
-            email 'dan.j.allen@gmail.com'
-            timezone '-7'
-            roles {
-                role 'Contributor'
+            issueManagement {
+                system = 'github'
+                url = 'https://github.com/asciidoctor/asciidoctorj-epub3/issues'
             }
-        }
-        developer {
-            id 'abelsromero'
-            name 'Abel Salgado Romero'
-            email 'abelromero@gmail.com'
-            timezone '1'
-            roles {
-                role 'Contributor'
+            scm {
+                url = 'https://github.com/asciidoctor/asciidoctorj-epub3'
             }
-        }
-        developer {
-            id 'robertpanzer'
-            name 'Robert Panzer'
-            email 'robert.panzer.pb@gmail.com'
-            timezone '1'
-            roles {
-                role 'Contributor'
+            developers {
+                developer {
+                    id = 'asotobu'
+                    name = 'Alex Soto Bueno'
+                    email = 'asotobu@gmail.com'
+                    timezone = '1'
+                    roles = ['Project Lead']
+                }
+                developer {
+                    id = 'mojavelinux'
+                    name = 'Dan Allen'
+                    email = 'dan.j.allen@gmail.com'
+                    timezone = '-7'
+                    roles = ['Contributor']
+                }
+                developer {
+                    id = 'abelsromero'
+                    name = 'Abel Salgado Romero'
+                    email = 'abelromero@gmail.com'
+                    timezone = '1'
+                    roles = ['Contributor']
+                }
+                developer {
+                    id = 'robertpanzer'
+                    name = 'Robert Panzer'
+                    email = 'robert.panzer.pb@gmail.com'
+                    timezone = '1'
+                    roles = ['Contributor']
+                }
             }
         }
     }
 }
 
-afterEvaluate {
-    publishing.publications {
-        jars(MavenPublication) {
-
-            // NOTE only build sources and javadoc jars when releasing
-            if (project.statusIsRelease) {
-                if (project.tasks.withType(Jar).findByName('sourcesJar')) {
-                    artifact sourcesJar
-                }
-                if (project.tasks.withType(Jar).findByName('javadocJar')) {
-                    artifact javadocJar
-                }
-            }
-
-            pom.withXml {
-                asNode().children().last() + projectMeta
-            }
-
-            from components.java
-        }
-    }
-}
-
-if ( !project.hasProperty('skip.signing') ) {
-    task addSignaturesToPublication(dependsOn: signArchives) {
-        group "publishing"
-        description "add all signatures to the publication"
-
-        doLast {
-            publishing.publications {
-                jars(MavenPublication) {
-                    configurations.signatures.getArtifacts().each { sig ->
-                        logger.debug "adding signature to jars publication: $sig"
-                        artifact(sig) {
-                            extension "jar.asc"
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    tasks["signPom"].finalizedBy addSignaturesToPublication
-}
 
 // QUESTION should we move manifest creation to general Java plugin config?
 jar {
-  manifest {
-    attributes \
+    manifest {
+        attributes \
       'Built-By': System.properties['user.name'],
-      'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
-      'Build-Date': buildDateOnly,
-      //'Build-Time': buildTimeOnly,
-      //'Specification-Title': project.name,
-      //'Specification-Version': project.version,
-      //'Specification-Vendor': 'asciidoctor.org',
-      'Implementation-Title': project.name,
-      'Implementation-Version': project.version,
-      'Implementation-Vendor': 'asciidoctor.org'
-  }
+        'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+        'Build-Date': buildDateOnly,
+        //'Build-Time': buildTimeOnly,
+        //'Specification-Title': project.name,
+        //'Specification-Version': project.version,
+        //'Specification-Vendor': 'asciidoctor.org',
+        'Implementation-Title': project.name,
+        'Implementation-Version': project.version,
+        'Implementation-Vendor': 'asciidoctor.org'
+    }
 }
+
+publishing {
+    repositories {
+        maven {
+            name = "local"
+            // change URLs to point to your repos, e.g. http://my.org/repo
+            def releasesRepoUrl = "${rootProject.buildDir}/repos/releases"
+            def snapshotsRepoUrl = "${rootProject.buildDir}/repos/snapshots"
+            url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
+        }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
+}
+

--- a/gradle/signing.gradle
+++ b/gradle/signing.gradle
@@ -1,60 +1,19 @@
-if ( !project.hasProperty('skip.signing') ){
+def hasSigningKey = project.hasProperty("signing.keyId") || project.findProperty("signingKey")
+if(hasSigningKey && !project.hasProperty('skip.signing')) {
     apply plugin: 'signing'
-
-    signing {
-        sign configurations.archives
-    }
-
-    if ( !signing.signatory ) {
-        logger.warn "No Signatory configured for project $project.name. Skip signing! See https://docs.gradle.org/current/userguide/signing_plugin.html"
-        signArchives.enabled = false
-        ext."skip.signing" = true
-    }
-
-    task signPom(type: Sign) {
-        group "publishing"
-        description "Sign the projects pom file"
-
-        ext.pom = file("$buildDir/publications/jars/pom-default.xml")
-        ext.signedPom = file("$buildDir/publications/jars/${project.name}-${project.version}.pom.asc")
-        ext.bintrayDestination = "${project.group.replace(".","/")}/${project.name}/${project.version}"
-
-        inputs.file pom
-        outputs.file signedPom
-
-        doLast{
-
-            def input = pom.newInputStream()
-            def output = signedPom.newOutputStream()
-            try{
-                signatory.sign(input, output)
-            }
-            catch (Exception e){
-                logger.error e.message
-            }
-            finally {
-                input.close()
-                output.close()
-            }
+    sign(project)
+}
+void sign(Project project) {
+    project.signing {
+        required { project.gradle.taskGraph.hasTask("required") }
+        def signingKeyId = project.findProperty("signingKeyId")
+        def signingKey = project.findProperty("signingKey")
+        def signingPassword = project.findProperty("signingPassword")
+        if (signingKeyId) {
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        } else if (signingKey) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
         }
-    }
-
-    /**
-     * The signPom Task depends on the GenerateMavenPom task which gets dynamically added
-     * with a name derived from a publication. In our case 'jars'.
-     *
-     * Our jars publication registers the signed pom as artifact.
-     * If the task does not run before publishJarsPublicationToMavenLocal this task will fail.
-     */
-    tasks.whenTaskAdded {
-
-        switch (it.name) {
-            case "generatePomFileForJarsPublication":
-                signPom.dependsOn it
-                break
-            case "publishJarsPublicationToMavenLocal":
-                it.dependsOn signPom
-                break
-        }
+        sign publishing.publications[project.ext.publicationName]
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/itest/build.gradle
+++ b/itest/build.gradle
@@ -6,9 +6,6 @@ dependencies {
 }
 
 jar.enabled = false
-if ( !project.hasProperty('skip.signing') ) {
-    signPom.enabled = false
-}
 
 configurations.all {
     artifacts.clear()


### PR DESCRIPTION
This PR updates the build to directly publish to Maven central instead of bintray.
To build a release follow these steps:


1. Update the version in gradle.properties to a release version, i.e. from 2.4.4-SNAPSHOT to 2.4.4.
2. Build the release with
  ```
  # ./gradlew clean build
  ```
3. After testing publish all artifacts to a local repository under build/repos with
  ```
  ./gradlew publishAllPublicationsToLocalRepository -i
  ```
4. When everything is fine publish the artifacts to a staging repository on https://oss.sonatype.org and close the repository:
  ```
  # ./gradlew publishAllPublicationsToSonatypeRepository -i
  # ./gradlew closeRepository -i
  ```
5. Visit https://oss.sonatype.org/#stagingRepositories and check the staging repository. The artifacts are not published yet.   The repository URL shown there can be used for testing this version before publishing to Maven central.
6. When everything is fine publish the artifacts in the staging repository by clicking the "Release" button. Alternatively you can release it with
  ```
  # ./gradlew releaseRepository
  ```
7. Commit everything and assign a tag:
  ```
  # git commit -m "Release v1.5.0-alpha.xy"
  # git tag v2.x.y
  ```
Upgrade the version to the next version by changing the version property in gradle.properties to version=1.5.0-alpha.xy+1-SNAPSHOT and commit:
  ```
  git commit -m "Prepare next release"
  ```
